### PR TITLE
Null check to prevent CPU worker to crash due to missing line for "model name" on /proc/cpuinfo of raspios 84

### DIFF
--- a/src/Infrastructure/PiControlPanel.Infrastructure.OnDemand/Services/CpuService.cs
+++ b/src/Infrastructure/PiControlPanel.Infrastructure.OnDemand/Services/CpuService.cs
@@ -218,8 +218,9 @@
 
             var cores = lines.Count(line => line.StartsWith("processor"));
             this.Logger.Trace($"Number of cores: '{cores}'");
-            var model = lines.Last(line => line.StartsWith("model name"))
-                .Split(':')[1].Trim();
+            var model = lines.Last(line => line.StartsWith("model name"));
+            model = string.IsNullOrWhiteSpace(model) ? "N/A" :
+                model.Split(':')[1].Trim();
             this.Logger.Trace($"Cpu model: '{model}'");
 
             result = BashCommands.CatBootConfig.Bash();


### PR DESCRIPTION
Summary of the changes:
- [x] Handling missing line of RaspiOS64

processor       : 0
~~model name      : ARMv7 Processor rev 3 (v7l)~~
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 1
~~model name      : ARMv7 Processor rev 3 (v7l)~~
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 2
~~model name      : ARMv7 Processor rev 3 (v7l)~~
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

processor       : 3
~~model name      : ARMv7 Processor rev 3 (v7l)~~
BogoMIPS        : 108.00
Features        : fp asimd evtstrm crc32 cpuid
CPU implementer : 0x41
CPU architecture: 8
CPU variant     : 0x0
CPU part        : 0xd08
CPU revision    : 3

Hardware        : BCM2835
Revision        : c03111
Serial          : 100000005e15efc1
Model           : Raspberry Pi 4 Model B Rev 1.1


closes #87 
