### PR TITLE
Narrowing commands that picontrolpanel can run as sudoer without password

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,4 @@
 *.sh text eol=lf
 *.sql text eol=lf
 *.service text eol=lf
-/package/pi-control-panel_*_armhf/DEBIAN/** text eol=lf
+/package/pi-control-panel_*_*/** text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,4 @@
 *.sh text eol=lf
 *.sql text eol=lf
 *.service text eol=lf
-/package/pi-control-panel_*_*/** text eol=lf
+/package/** text eol=lf

--- a/package/pi-control-panel_VERSION_ARCHITECTURE/DEBIAN/control
+++ b/package/pi-control-panel_VERSION_ARCHITECTURE/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: pi-control-panel
-Version: 1.35
+Version: 1.36
 Architecture: armhf
 Essential: no
 Priority: optional

--- a/package/pi-control-panel_VERSION_ARCHITECTURE/DEBIAN/postinst
+++ b/package/pi-control-panel_VERSION_ARCHITECTURE/DEBIAN/postinst
@@ -107,7 +107,6 @@ case "$1" in
         fi
         # End of Configuring port
         
-        chmod +x /opt/picontrolpanel/PiControlPanel.Api.GraphQL
         systemctl enable picontrolpanel
         systemctl start picontrolpanel
         

--- a/package/pi-control-panel_VERSION_ARCHITECTURE/DEBIAN/postrm
+++ b/package/pi-control-panel_VERSION_ARCHITECTURE/DEBIAN/postrm
@@ -23,7 +23,6 @@ case "$1" in
     
         rm -fr /var/log/picontrolpanel
         rm -fr /var/db/picontrolpanel
-        sed --in-place '/picontrolpanel ALL=(ALL) NOPASSWD: ALL/d' /etc/sudoers
         killall -9 -u picontrolpanel || true
         userdel picontrolpanel
 

--- a/package/pi-control-panel_VERSION_ARCHITECTURE/DEBIAN/preinst
+++ b/package/pi-control-panel_VERSION_ARCHITECTURE/DEBIAN/preinst
@@ -21,7 +21,6 @@ case "$1" in
         	useradd -M picontrolpanel
         	echo picontrolpanel:v!p4S#hM | chpasswd
         	usermod -aG sudo picontrolpanel
-        	echo 'picontrolpanel ALL=(ALL) NOPASSWD: ALL' | EDITOR='tee -a' visudo
         	usermod -aG video picontrolpanel
         fi
         

--- a/package/pi-control-panel_VERSION_ARCHITECTURE/etc/sudoers.d/010_picontrolpanel-nopasswd
+++ b/package/pi-control-panel_VERSION_ARCHITECTURE/etc/sudoers.d/010_picontrolpanel-nopasswd
@@ -1,0 +1,1 @@
+picontrolpanel ALL=(ALL) NOPASSWD: /bin/sed, /bin/kill, /bin/cat, /sbin/shutdown, /sbin/reboot

--- a/package/pi-control-panel_VERSION_ARCHITECTURE/etc/sudoers.d/010_picontrolpanel-nopasswd
+++ b/package/pi-control-panel_VERSION_ARCHITECTURE/etc/sudoers.d/010_picontrolpanel-nopasswd
@@ -1,1 +1,1 @@
-picontrolpanel ALL=(ALL) NOPASSWD: /bin/sed, /bin/kill, /bin/cat, /sbin/shutdown, /sbin/reboot
+picontrolpanel ALL=(ALL) NOPASSWD: /bin/sed, /bin/kill, /bin/cat, /sbin/shutdown

--- a/src/Domain/PiControlPanel.Domain.Contracts/Constants/BashCommands.cs
+++ b/src/Domain/PiControlPanel.Domain.Contracts/Constants/BashCommands.cs
@@ -16,9 +16,9 @@
         public const string CatCpuFreqStats = "cat /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state";
 
         /// <summary>
-        /// Reboots the system, equivalent to shutdown -r now.
+        /// Reboots the system, equivalent to reboot.
         /// </summary>
-        public const string SudoReboot = "sudo reboot";
+        public const string SudoReboot = "sudo shutdown -r now";
 
         /// <summary>
         /// Shutdown linux.


### PR DESCRIPTION
Summary of the changes:
- [x] Narrowing commands that picontrolpanel can run as sudoer without password

closes #96 
