### PR TITLE
Sync system clock before apt-get

### DIFF
--- a/package/pi-control-panel_VERSION_ARCHITECTURE/DEBIAN/control
+++ b/package/pi-control-panel_VERSION_ARCHITECTURE/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: pi-control-panel
-Version: 1.55
+Version: 1.56
 Architecture: armhf
 Essential: no
 Priority: optional

--- a/src/Domain/PiControlPanel.Domain.Contracts/Constants/BashCommands.cs
+++ b/src/Domain/PiControlPanel.Domain.Contracts/Constants/BashCommands.cs
@@ -151,8 +151,13 @@
         public const string Netstat = "netstat -tln | grep ':{0} '";
 
         /// <summary>
-        /// Starts a service.
+        /// Controls the systemd system and service manager.
         /// </summary>
-        public const string SudoSystemctlStart = "sudo systemctl start {0}";
+        public const string SudoSystemctl = "sudo systemctl {0}";
+
+        /// <summary>
+        /// Controls the system time and date.
+        /// </summary>
+        public const string Timedatectl = "timedatectl";
     }
 }

--- a/src/Infrastructure/PiControlPanel.Infrastructure.OnDemand/Services/ControlPanelService.cs
+++ b/src/Infrastructure/PiControlPanel.Infrastructure.OnDemand/Services/ControlPanelService.cs
@@ -205,7 +205,7 @@
         public async Task<bool> StartSshAsync()
         {
             this.logger.Debug("Infra layer -> ControlPanelService -> StartSshAsync");
-            var startSshService = string.Format(BashCommands.SudoSystemctlStart, "ssh");
+            var startSshService = string.Format(BashCommands.SudoSystemctl, "start ssh");
             var result = await startSshService.BashAsync();
             if (!string.IsNullOrEmpty(result))
             {


### PR DESCRIPTION
Summary of the changes:
- [x] Run apt-get update only after system clock is synchronized

closes #118 
