### PR TITLE
Simplify usage of CliWrap

### DIFF
--- a/src/Infrastructure/PiControlPanel.Infrastructure.OnDemand/Util/ShellExtensions.cs
+++ b/src/Infrastructure/PiControlPanel.Infrastructure.OnDemand/Util/ShellExtensions.cs
@@ -19,15 +19,12 @@
         /// <returns>The result of the bash command.</returns>
         public static async Task<string> BashAsync(this string cmd)
         {
-            var escapedArgs = cmd.Replace("\"", "\\\"");
-            var command = Cli.Wrap("/bin/bash").WithArguments($"-c \"{escapedArgs}\"");
+            var command = Cli.Wrap("/bin/bash").WithArguments(new[] { "-c", cmd });
 
             try
             {
                 var result = await command.ExecuteBufferedAsync();
-                return result?.StandardOutput == null ?
-                    string.Empty :
-                    result.StandardOutput.TrimEnd(Environment.NewLine.ToCharArray());
+                return result.StandardOutput.TrimEnd(Environment.NewLine.ToCharArray());
             }
             catch (CommandExecutionException ex)
             {


### PR DESCRIPTION
Hi there! 🙂 
I was looking through projects using CliWrap and noticed this repo.

Decided to give a small refactor to simplify things a bit 😉 
- You don't need to escape arguments yourself. If you use the array or builder overload, CliWrap takes care of this for you. In this case, every individual element in the array is treated as a separate argument and will be encoded accordingly.
- Neither `result` nor `result.StandardOutput` can ever be null, so there's no reason to check for that either.